### PR TITLE
Mac / Linux doesn't have PowerShell, use bash syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ $env:GOOGLE_APPLICATION_CREDENTIALS="./example.json"
 
 For Mac/Linux:
 ```
-$env:GOOGLE_APPLICATION_CREDENTIALS="./example.json"
+export GOOGLE_APPLICATION_CREDENTIALS="./example.json"
 ```
 
 To install express:


### PR DESCRIPTION
Use bash syntax to set `GOOGLE_APPLICATION_CREDENTIALS`. The current way is PowerShell syntax.